### PR TITLE
Add missing ":" after the group name

### DIFF
--- a/rich_argparse.py
+++ b/rich_argparse.py
@@ -144,7 +144,7 @@ class RichHelpFormatter(argparse.RawTextHelpFormatter, argparse.RawDescriptionHe
 
         if self.renderables or self._table.row_count:
             title = type(self).group_name_formatter(self._current_section.heading or "")
-            self.renderables.insert(0, f"[argparse.groups]{title}")
+            self.renderables.insert(0, f"[argparse.groups]{title}:")
             if self._table.row_count:
                 self.renderables.append(self._table)
         renderables = self.renderables

--- a/tests/test_poetry_clone.py
+++ b/tests/test_poetry_clone.py
@@ -8,7 +8,7 @@ from tests.conftest import assert_help_output
 _POETRY_CLONE_HELP = """\
 usage: poetry [-h] [-q] [-v] [-V] [--ansi] [--no-ansi] [-n] <command> ...
 
-GLOBAL OPTIONS
+GLOBAL OPTIONS:
   -h, --help            Display this help message
   -q, --quiet           Do not output any message
   -v, --verbose         Increase the verbosity of messages: "-v" for normal output, "-vv" for more
@@ -18,7 +18,7 @@ GLOBAL OPTIONS
   --no-ansi             Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
 
-AVAILABLE COMMANDS
+AVAILABLE COMMANDS:
   <command>             The command to execute
     about               Shows information about Poetry.
     add                 Adds a new dependency to pyproject.toml.
@@ -49,10 +49,10 @@ AVAILABLE COMMANDS
 _POETRY_CLONE_HELP_HELP = """\
 usage: poetry help [-h] [-q] [-v] [-V] [--ansi] [--no-ansi] [-n] [<command>]
 
-POSITIONAL ARGUMENTS
+POSITIONAL ARGUMENTS:
   <command>             The command name
 
-GLOBAL OPTIONS
+GLOBAL OPTIONS:
   -h, --help            Display this help message
   -q, --quiet           Do not output any message
   -v, --verbose         Increase the verbosity of messages: "-v" for normal output, "-vv" for more

--- a/tests/test_rich_argparse.py
+++ b/tests/test_rich_argparse.py
@@ -20,7 +20,7 @@ def test_text_replaces_prog():
 
     This is the awesome_program program.
 
-    {OPTIONS_GROUP_NAME}
+    {OPTIONS_GROUP_NAME}:
       -h, --help  show this help message and exit
       --version   show program's version number and exit
     """
@@ -47,10 +47,10 @@ def test_spans():
     expected_help_output += f"""\
 
 
-    \x1b[1;3;38;5;208mPOSITIONAL ARGUMENTS\x1b[0m
+    \x1b[1;3;38;5;208mPOSITIONAL ARGUMENTS:\x1b[0m
       \x1b[3;36mfile\x1b[0m
 
-    \x1b[1;3;38;5;208m{OPTIONS_GROUP_NAME}\x1b[0m
+    \x1b[1;3;38;5;208m{OPTIONS_GROUP_NAME}:\x1b[0m
       \x1b[3;36m-h\x1b[0m, \x1b[3;36m--help\x1b[0m  \x1b[39mshow this help message and exit\x1b[0m
       \x1b[3;36m--flag\x1b[0m      \x1b[39mIs flag?\x1b[0m
     """


### PR DESCRIPTION
Apparently `argparse.HelpFormatter` adds a `:` after the group name. This formatter should do the same.