### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox
-        run: |
-          pip install --upgrade pip tox
+        run: pip install --upgrade pip tox
       - name: Run the test suite
         run: tox -e py
+      - name: Upload coverage report if tests fail.
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report-${{ runner.os }}-python-${{ matrix.python }}
+          path: htmlcov
+        if: ${{ failure() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Features
+- Metavars now have their own style `argparse.metavar` which defaults to `'bold cyan'`
+  * Issue #4, PR #9
+
+### Fixes
+- Add missing ":" after the group name similar to the default HelpFormatter
+  * Issue #4, PR #10
+- Fix padding of long options or metavars
+  * PR #11
+- Fix overflow of text in help that was truncated
+  * PR #11
+- Escape parameters that get substituted with % such as %(prog)s and %(default)s
+  * PR #11
+- Fix flaky wrapping of long lines
+  * PR #11
+
 ## 0.1.1 - 2022-09-10
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Format **argparse** help output with [**rich**](https://pypi.org/project/rich).
 
 ![python -m rich_argparse --help](
-https://user-images.githubusercontent.com/93259987/172022148-a6a1dc93-9d25-47da-8b7c-e04a828d50f9.png)
+https://user-images.githubusercontent.com/93259987/190869857-963968f4-b273-4c93-a301-958fef487624.png)
 
 
 ## Installation
@@ -140,5 +140,5 @@ setting the `RichHelpFormatter.group_name_formatter` to any function that takes 
 an input and returns a str. By default, `RichHelpFormatter` sets the function to `str.upper`.
 
 ```python
-RichHelpFormatter.group_name_formatter = lambda name: name.title() + ':'
+RichHelpFormatter.group_name_formatter = str.title
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,4 @@ module = ["tests.*"]
 check_untyped_defs = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
+disallow_untyped_decorators = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,12 @@ skip_missing_interpreters = true
 [testenv]
 deps =
   pytest
+  coverage[toml]
+  covdefaults
 commands =
-  pytest {posargs}
+  coverage erase
+  coverage run -m pytest {posargs}
+  coverage report
 """
 
 [tool.black]
@@ -62,3 +66,14 @@ check_untyped_defs = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 disallow_untyped_decorators = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+plugins = ["covdefaults"]
+source = ["rich_argparse"]
+
+[tool.coverage.report]
+ignore_errors = true
+fail_under = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,16 +18,22 @@ def set_terminal_columns():
         yield
 
 
-def assert_help_output(
-    parser: argparse.ArgumentParser, cmd: list[str], expected_output: str, with_ansi: bool = False
-) -> None:
+def get_help_output(
+    parser: argparse.ArgumentParser, cmd: list[str], with_ansi: bool = False
+) -> str:
     __tracebackhide__ = True
     stdout = io.StringIO()
     stdout.isatty = lambda: with_ansi  # type: ignore[assignment]
     with pytest.raises(SystemExit), patch.object(sys, "stdout", stdout):
         parser.parse_args(cmd)
-    out = stdout.getvalue()
+    return stdout.getvalue()
 
+
+def assert_help_output(
+    parser: argparse.ArgumentParser, cmd: list[str], expected_output: str, with_ansi: bool = False
+) -> None:
+    __tracebackhide__ = True
+    out = get_help_output(parser, cmd, with_ansi)
     out_lines = out.splitlines()
     expected_out_lines = textwrap.dedent(expected_output).splitlines()
     assert len(out_lines) == len(expected_out_lines)

--- a/tests/test_rich_argparse.py
+++ b/tests/test_rich_argparse.py
@@ -231,3 +231,10 @@ def test_spans():
       \x1b[3;36m--flag\x1b[0m      \x1b[39mIs flag?\x1b[0m
     """
     assert_help_output(parser, cmd=["--help"], expected_output=expected_help_output, with_ansi=True)
+
+
+def test_no_help():
+    formatter = RichHelpFormatter("prog")
+    formatter.add_usage(usage=argparse.SUPPRESS, actions=[], groups=[])
+    out = formatter.format_help()
+    assert not out

--- a/tests/test_rich_argparse.py
+++ b/tests/test_rich_argparse.py
@@ -1,34 +1,164 @@
 from __future__ import annotations
 
 import argparse
+from typing import Any
+from unittest.mock import patch
+
+import pytest
 
 from rich_argparse import RichHelpFormatter
-from tests.conftest import OPTIONS_GROUP_NAME, assert_help_output
+from tests.conftest import OPTIONS_GROUP_NAME, assert_help_output, get_help_output
 
 
-def test_text_replaces_prog():
-    # https://github.com/hamdanal/rich-argparse/issues/5
+def test_params_substitution():
+    # in text (description, epilog, group description) and version: substitute %(prog)s
+    # in help message: substitute %(param)s for all param in vars(action)
     parser = argparse.ArgumentParser(
         "awesome_program",
         description="This is the %(prog)s program.",
+        epilog="The epilog of %(prog)s.",
         formatter_class=RichHelpFormatter,
     )
     parser.add_argument("--version", action="version", version="%(prog)s 1.0.0")
+    parser.add_argument("--option", default="value", help="help of option (default: %(default)s)")
 
     expected_help_output = f"""\
-    usage: awesome_program [-h] [--version]
+    usage: awesome_program [-h] [--version] [--option OPTION]
 
     This is the awesome_program program.
 
     {OPTIONS_GROUP_NAME}:
-      -h, --help  show this help message and exit
-      --version   show program's version number and exit
+      -h, --help       show this help message and exit
+      --version        show program's version number and exit
+      --option OPTION  help of option (default: value)
+
+    The epilog of awesome_program.
     """
     expected_version_output = """\
     awesome_program 1.0.0
     """
     assert_help_output(parser, cmd=["--version"], expected_output=expected_version_output)
     assert_help_output(parser, cmd=["--help"], expected_output=expected_help_output)
+
+
+@pytest.mark.parametrize("prog", (None, "PROG"))
+@pytest.mark.parametrize("usage", (None, "USAGE"))
+@pytest.mark.parametrize("description", (None, "This is the program's description."))
+@pytest.mark.parametrize("epilog", (None, "This is the program's epilog."))
+def test_overall_structure(
+    prog: str | None, usage: str | None, description: str | None, epilog: str | None
+):
+    # The output must be consistent with the original HelpFormatter in these cases:
+    # 1. all names and help text are short to avoid special wrapping
+    # 2. no short and long options with args are used
+    # 3. group_name_formatter is disabled
+    # 4. colors are disabled
+    # 5. no markup/emoji codes are used
+    # 6. trailing whitespace is ignored
+    parser = argparse.ArgumentParser(prog, usage=usage, description=description, epilog=epilog)
+    parser.add_argument("file", default="-", help="A file (default: %(default)s).")
+
+    # all types of empty groups
+    parser.add_argument_group("empty group name", description="empty_group description")
+    parser.add_argument_group("no description empty group name")
+    parser.add_argument_group("", description="empty_name_empty_group description")
+    parser.add_argument_group(description="no_name_empty_group description")
+
+    # all types of non-empty groups
+    group = parser.add_argument_group("group name", description="group description")
+    group.add_argument("arg", help="help inside group")
+    no_desc_group = parser.add_argument_group("no description group name")
+    no_desc_group.add_argument("arg", help="agr help inside no_desc_group")
+    empty_name_group = parser.add_argument_group(description="empty_name_group description")
+    empty_name_group.add_argument("arg", help="arg help inside empty_name_group")
+    no_name_group = parser.add_argument_group(description="no_name_group description")
+    no_name_group.add_argument("arg", help="arg help inside no_name_group")
+    no_name_no_desc_group = parser.add_argument_group()
+    no_name_no_desc_group.add_argument("arg", help="arg help inside no_name_no_desc_group")
+
+    orig_out = get_help_output(parser, cmd=["--help"])
+    parser.formatter_class = RichHelpFormatter
+    with patch.object(RichHelpFormatter, "group_name_formatter", str):
+        rich_out = get_help_output(parser, cmd=["--help"])
+    rich_out_no_trailing_ws = "\n".join(line.rstrip(" ") for line in rich_out.split("\n"))
+    assert rich_out_no_trailing_ws == orig_out
+
+
+def test_padding_and_wrapping():
+    # padding of group descritpion works as expected even when wrapped
+    # wrapping of options work as expected
+    parser = argparse.ArgumentParser(
+        "PROG", description="-" * 120, epilog="%" * 120, formatter_class=RichHelpFormatter
+    )
+    parser.add_argument("-o", "--very-long-option-name", metavar="LONG_METAVAR", help="." * 120)
+    group_with_description = parser.add_argument_group("group", description="*" * 120)
+    group_with_description.add_argument("pos-arg", help="#" * 120)
+
+    expected_help_output = f"""\
+    usage: PROG [-h] [-o LONG_METAVAR] pos-arg
+
+    --------------------------------------------------------------------------------------------------
+    ----------------------
+
+    {OPTIONS_GROUP_NAME}:
+      -h, --help                           show this help message and exit
+      -o, --very-long-option-name          ...........................................................
+    LONG_METAVAR                           ...........................................................
+                                           ..
+
+    GROUP:
+      ************************************************************************************************
+      ************************
+
+      pos-arg                              ###########################################################
+                                           ###########################################################
+                                           ##
+
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %%%%%%%%%%%%%%%%%%%%%%
+    """
+    assert_help_output(parser, cmd=["--help"], expected_output=expected_help_output)
+
+
+@pytest.mark.parametrize("title", (None, "available commands"))
+@pytest.mark.parametrize("description", (None, "subparsers description"))
+@pytest.mark.parametrize("dest", (None, "command"))
+@pytest.mark.parametrize("metavar", (None, "<command>"))
+@pytest.mark.parametrize("help", (None, "The subcommand to execute"))
+@pytest.mark.parametrize("required", (False, True))
+def test_subparsers(
+    title: str | None,
+    description: str | None,
+    dest: str | None,
+    metavar: str | None,
+    help: str | None,
+    required: bool,
+):
+    parser = argparse.ArgumentParser()
+
+    kwargs: dict[str, Any] = {
+        "title": title,
+        "description": description,
+        "dest": dest,
+        "metavar": metavar,
+        "help": help,
+        "required": required,
+    }
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    subparsers = parser.add_subparsers(**kwargs)
+    help_subparser = subparsers.add_parser("help", help="help subcommand.")
+
+    orig_out = get_help_output(parser, cmd=["--help"])
+    orig_help_out = get_help_output(parser, cmd=["help", "--help"])
+    parser.formatter_class = RichHelpFormatter
+    help_subparser.formatter_class = RichHelpFormatter
+    with patch.object(RichHelpFormatter, "group_name_formatter", str):
+        rich_out = get_help_output(parser, cmd=["--help"])
+        rich_help_out = get_help_output(parser, cmd=["help", "--help"])
+    rich_out_no_trailing_ws = "\n".join(line.rstrip(" ") for line in rich_out.split("\n"))
+    rich_help_out_no_trailing_ws = "\n".join(line.rstrip(" ") for line in rich_help_out.split("\n"))
+    assert rich_out_no_trailing_ws == orig_out
+    assert rich_help_out_no_trailing_ws == orig_help_out
 
 
 def test_spans():


### PR DESCRIPTION
Fix the following:
1. padding with long options or metavars
2. overflow of text in help that was truncated
3. escape parameters that get substituted with % such as `%(prog)s` and `%(default)s`
4. wrapping long lines was flaky