### PR TITLE
Do not wrap long options

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -9,6 +9,7 @@
         "isort",
         "kwargs",
         "mypy",
+        "positionals",
         "pypi",
         "pyupgrade",
         "yesqa"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Format **argparse** help output with [**rich**](https://pypi.org/project/rich).
 
 ![python -m rich_argparse --help](
-https://user-images.githubusercontent.com/93259987/192895487-7772b686-9380-4c5d-8b18-a6243fe02c32.png)
+https://user-images.githubusercontent.com/93259987/193126185-6f7cd2dd-4e74-40ea-a194-a5e045a6f7a1.png)
 
 
 ## Installation


### PR DESCRIPTION
Fixes #12 
* The formatter now expands options to the right instead of wrapping them similar to what HelpFormatter does.
* Also since since the formatter now renders properly even with small `max_help_position`, it was restored to the original default.
* The undocumented RichHelpFormatter.renderables property was deleted.