### PR TITLE
Support RawDescription / RawText help formatters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
-        run: pip install --upgrade pip tox
+        run: pip install --upgrade tox
       - name: Run the test suite
         run: tox -e py -- -vv
       - name: Upload coverage report if tests fail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Code changes must not trigger linting errors by [flake8].
 
 ## Creating a Pull Request
 
-Once your happy with your change and have ensured that all steps above have been followed (and
+Once you are happy with your change and have ensured that all steps above have been followed (and
 checks have passed), you can create a pull request. GitHub offers a guide on how to do this
 [here][PR]. Please ensure that you include a good description of what your change does in your
 pull request, and link it to any relevant issues or discussions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ commands =
   coverage erase
   coverage run -m pytest {posargs}
   coverage report
+  coverage html
 """
 
 [tool.black]

--- a/rich_argparse.py
+++ b/rich_argparse.py
@@ -1,22 +1,31 @@
+# Source code: https://github.com/hamdanal/rich-argparse
+# MIT license: Copyright (c) Ali Hamdan <ali.hamdan.dev@gmail.com>
 from __future__ import annotations
 
 import argparse
 import sys
-from typing import TYPE_CHECKING, Callable, Generator, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator
 
 # rich is only used to display help. It is imported inside the functions in order
 # not to add delays to command line tools that use this formatter.
 if TYPE_CHECKING:
     from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+    from rich.containers import Lines
     from rich.style import StyleType
     from rich.text import Span, Text
 
-__all__ = ["RichHelpFormatter"]
+__all__ = [
+    "RichHelpFormatter",
+    "RawDescriptionRichHelpFormatter",
+    "RawTextRichHelpFormatter",
+    "ArgumentDefaultsRichHelpFormatter",
+    "MetavarTypeRichHelpFormatter",
+]
 _Actions = Iterable[argparse.Action]
 _Groups = Iterable[argparse._ArgumentGroup]
 
 
-class RichHelpFormatter(argparse.RawTextHelpFormatter):
+class RichHelpFormatter(argparse.HelpFormatter):
     """An argparse HelpFormatter class that renders using rich."""
 
     group_name_formatter: Callable[[str], str] = str.upper
@@ -40,110 +49,111 @@ class RichHelpFormatter(argparse.RawTextHelpFormatter):
         max_help_position: int = 24,
         width: int | None = None,
     ) -> None:
-        super().__init__(prog, indent_increment, max_help_position, width)
-        self._root_section.rich = []
+        from rich.console import Console
+        from rich.theme import Theme
 
-    class _RichSection:
-        def __init__(self, formatter: RichHelpFormatter, heading: str | None) -> None:
-            self.formatter = formatter
+        super().__init__(prog, indent_increment, max_help_position, width)
+        self.console = Console(theme=Theme(self.styles), width=5000)
+
+    class _Section(argparse.HelpFormatter._Section):  # type: ignore[valid-type,misc]
+        def __init__(
+            self,
+            formatter: RichHelpFormatter,
+            parent: RichHelpFormatter._Section,
+            heading: str | None = None,
+        ) -> None:
             if heading is not None:
                 heading = f"{type(formatter).group_name_formatter(heading)}:"
-            self.heading = heading
-            self.description: Text | None = None
-            self.actions: list[tuple[Text, Text]] = []
+            super().__init__(formatter, parent, heading)
+            self.rich_items: list[RenderableType] = []
+            self.rich_actions: list[tuple[Text, Text | None]] = []
+            if parent is not None:
+                parent.rich_items.append(self)
 
         def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-            from rich.table import Column, Table
             from rich.text import Text
 
-            # assert the empty sections are never rendered
-            assert self.description or self.actions
-            help_position = min(
-                self.formatter._action_max_length + 2, self.formatter._max_help_position
-            )
+            if not self.rich_items and not self.rich_actions:  # empty section
+                return
+            fmt: RichHelpFormatter = self.formatter
+            if self is fmt._root_section:  # root section
+                yield from self.rich_items
+                return
+            help_position = min(fmt._action_max_length + 2, fmt._max_help_position)
+            help_width = max(fmt._width - help_position, 11)
             if self.heading:
                 yield Text(self.heading, style="argparse.groups")
-            if self.description:
-                yield self.description
-                if self.actions:
-                    yield ""  # add empty line between the description and the arguments
-            table = Table.grid(Column(width=help_position), Column(overflow="fold"))
-            for action_header, action_help in self.actions:
-                if len(action_header) >= help_position - 1:
-                    table.add_row(*action_header.divide([help_position]))
-                    if action_help:
-                        table.add_row(None, action_help)
-                else:
-                    table.add_row(action_header, action_help)
-            yield table
+            yield from self.rich_items  # (optional) group description
+            indent = Text(" " * help_position)
+            for action_header, action_help in self.rich_actions:
+                if not action_help:
+                    yield action_header  # no help, yield the header and finish
+                    continue
+                action_help_lines = fmt._rich_split_lines(action_help, help_width)
+                if len(action_header) > help_position - 2:
+                    yield action_header  # the header is too long, put it on its own line
+                    action_header = indent
+                action_header.set_length(help_position)
+                action_help_lines[0].rstrip()
+                yield action_header + action_help_lines[0]
+                for line in action_help_lines[1:]:
+                    line.rstrip()
+                    yield indent + line
+            yield "\n"
 
-    def _is_root(self) -> bool:
-        return self._current_section == self._root_section  # type: ignore[no-any-return]
+    def add_text(self, text: str | None) -> None:
+        if text is not argparse.SUPPRESS and text is not None:
+            self._current_section.rich_items.append(self._rich_format_text(text))
 
-    def _rich_append(self, r: RenderableType) -> None:
-        assert self._is_root(), "can only append in root"
-        if isinstance(r, RichHelpFormatter._RichSection) and not r.description and not r.actions:
+    def add_usage(
+        self, usage: str | None, actions: _Actions, groups: _Groups, prefix: str | None = None
+    ) -> None:
+        if usage is argparse.SUPPRESS:
             return
-        if self._root_section.rich:
-            self._root_section.rich.append("")
-        self._root_section.rich.append(r)
+        from rich.text import Span, Text
 
-    def _escape_params_and_expand_help(self, action: argparse.Action) -> str:
-        from rich.markup import escape
+        if prefix is None:
+            prefix = self._format_usage(usage="", actions=(), groups=(), prefix=None).rstrip("\n")
+        prefix_end = ": " if prefix.endswith(": ") else ""
+        prefix = prefix[: len(prefix) - len(prefix_end)]
+        prefix = type(self).group_name_formatter(prefix) + prefix_end
 
-        if not action.help:
-            return ""
-        params = dict(vars(action), prog=self._prog)
-        for name in list(params):  # iterate over a copy because del
-            param = params[name]
-            if param is argparse.SUPPRESS:
-                del params[name]
-            elif hasattr(param, "__name__"):
-                params[name] = param.__name__
-            elif name == "choices" and param is not None:
-                params[name] = ", ".join([str(c) for c in param])
-        params = {k: escape(str(v)) for k, v in params.items()}
-        return self._get_help_string(action) % params  # type: ignore[operator]
+        usage_spans = [Span(0, len(prefix.rstrip()), "argparse.groups")]
+        usage_text = self._format_usage(usage, actions, groups, prefix=prefix)
+        if usage is None:  # only auto generated usage is coloured
+            actions_start = len(prefix) + len(self._prog) + 1
+            try:
+                spans = list(self._rich_usage_spans(usage_text, actions_start, actions=actions))
+            except ValueError:
+                spans = []
+            usage_spans.extend(spans)
+        self._root_section.rich_items.append(Text(usage_text, spans=usage_spans))
 
-    def _format_action_invocation(self, action: argparse.Action) -> str:
-        orig_str = super()._format_action_invocation(action)
+    def add_argument(self, action: argparse.Action) -> None:
+        super().add_argument(action)
+        if action.help is not argparse.SUPPRESS:
+            self._current_section.rich_actions.extend(self._rich_format_action(action))
 
-        if not self._is_root():
-            from rich.text import Span, Text
+    def format_help(self) -> str:
+        with self.console.capture() as capture:
+            self.console.print(self._root_section)
+        help = capture.get()
+        if help:
+            help = self._long_break_matcher.sub("\n\n", help).strip("\n") + "\n"
+            help = "\n".join(line.rstrip() for line in help.split("\n"))
+        return help
 
-            if not action.option_strings:
-                action_invocation = Text(orig_str, spans=[Span(0, len(orig_str), "argparse.args")])
-            else:
-                styled_options = (Text(opt, style="argparse.args") for opt in action.option_strings)
-                action_invocation = Text(", ").join(styled_options)
-                if action.nargs != 0:
-                    # The default format: `-s ARGS, --long-option ARGS` is very ugly with long
-                    # option names so I change it to `-s, --long-option ARG` similar to click
-                    default = self._get_default_metavar_for_optional(action)
-                    args_string = self._format_args(action, default)
-                    action_invocation.append(" ")
-                    action_invocation.append(args_string, style="argparse.metavar")
-
-            action_invocation.pad_left(self._current_indent)
-            help_text = Text.from_markup(self._escape_params_and_expand_help(action))
-            help_text.spans.insert(0, Span(0, len(help_text), style="argparse.help"))
-            for regex in self.highlights:
-                help_text.highlight_regex(regex, style_prefix="argparse.")
-            self._current_section.rich.actions.append((action_invocation, help_text))
-
-        return orig_str
-
-    def _usage_spans(self, text: str, start: int, actions: _Actions) -> Generator[Span, None, None]:
+    # ===============
+    # Utility methods
+    # ===============
+    def _rich_usage_spans(self, text: str, start: int, actions: _Actions) -> Iterator[Span]:
         from rich.text import Span
 
-        options, positionals = [], []
-        for action in actions:  # split into options and positionals
-            if action.help is argparse.SUPPRESS:
-                continue
-            if action.option_strings:
-                options.append(action)
-            else:
-                positionals.append(action)
+        options: list[argparse.Action] = []
+        positionals: list[argparse.Action] = []
+        for action in actions:
+            if action.help is not argparse.SUPPRESS:
+                options.append(action) if action.option_strings else positionals.append(action)
         pos = start
         for action in options:  # start with the options
             if sys.version_info >= (3, 9):  # pragma: >=3.9 cover
@@ -173,68 +183,107 @@ class RichHelpFormatter(argparse.RawTextHelpFormatter):
             yield Span(start, end, "argparse.args")
             pos = end + 1
 
-    def add_usage(
-        self, usage: str | None, actions: _Actions, groups: _Groups, prefix: str | None = None
-    ) -> None:
-        super().add_usage(usage, actions, groups, prefix)
-        if usage is argparse.SUPPRESS:
-            return
-        from rich.text import Span, Text
+    def _rich_whitespace_sub(self, text: Text) -> Text:
+        # do this `self._whitespace_matcher.sub(' ', text).strip()` but text is Text
+        spans = [m.span() for m in self._whitespace_matcher.finditer(text.plain)]
+        for start, end in reversed(spans):
+            if end - start > 1:  # slow path
+                space = text[start : start + 1]
+                space.plain = " "
+                text = text[:start] + space + text[end:]
+            else:  # performance shortcut
+                text.plain = text.plain[:start] + " " + text.plain[end:]
+        # Text has no strip method yet
+        lstrip_at = len(text.plain) - len(text.plain.lstrip())
+        if lstrip_at:
+            text = text[lstrip_at:]
+        text.rstrip()
+        return text
 
-        if prefix is None:
-            prefix = self._format_usage(usage="", actions=(), groups=(), prefix=None).rstrip("\n")
-        prefix_end = ": " if prefix.endswith(": ") else ""
-        prefix = prefix[: len(prefix) - len(prefix_end)]
-        prefix = type(self).group_name_formatter(prefix) + prefix_end
+    # =====================================
+    # Rich version of HelpFormatter methods
+    # =====================================
+    def _rich_expand_help(self, action: argparse.Action) -> Text:
+        from rich.markup import escape
+        from rich.text import Text
 
-        spans = [Span(0, len(prefix.rstrip()), "argparse.groups")]
-        usage_text = self._format_usage(usage, actions, groups, prefix=prefix).rstrip()
-        if usage is None:  # only auto generated usage is coloured
-            actions_start = len(prefix) + len(self._prog) + 1
-            try:
-                actions_spans = list(self._usage_spans(usage_text, actions_start, actions=actions))
-            except ValueError:
-                actions_spans = []
-            spans.extend(actions_spans)
-        self._rich_append(Text(usage_text, spans=spans))
+        params = dict(vars(action), prog=self._prog)
+        for name in list(params):
+            if params[name] is argparse.SUPPRESS:
+                del params[name]
+            elif hasattr(params[name], "__name__"):
+                params[name] = params[name].__name__
+        if params.get("choices") is not None:
+            params["choices"] = ", ".join([str(c) for c in params["choices"]])
+        params = {k: escape(str(v)) for k, v in params.items()}
+        help_string = self._get_help_string(action) % params  # type: ignore[operator]
+        rich_help = Text.from_markup(help_string, style="argparse.help")
+        rich_help.highlight_regex("|".join(self.highlights), style_prefix="argparse.")
+        return rich_help
 
-    def add_text(self, text: str | None) -> None:
-        super().add_text(text)
-        if text is not argparse.SUPPRESS and text is not None:
-            from rich.markup import escape
-            from rich.padding import Padding
-            from rich.text import Text
+    def _rich_format_text(self, text: str) -> Text:
+        from rich.markup import escape
+        from rich.text import Text
 
-            if "%(prog)" in text:
-                text = text % {"prog": escape(self._prog)}
-            rich_text = Text.from_markup(text, style="argparse.text")
-            for regex in self.highlights:
-                rich_text.highlight_regex(regex, style_prefix="argparse.")
-            padded_text = Padding.indent(rich_text, self._current_indent)
-            if self._is_root():
-                self._rich_append(padded_text)
-            else:
-                self._current_section.rich.description = padded_text
+        if "%(prog)" in text:
+            text = text % {"prog": escape(self._prog)}
+        rich_text = Text.from_markup(text, style="argparse.text")
+        rich_text.highlight_regex("|".join(self.highlights), style_prefix="argparse.")
+        text_width = max(self._width - self._current_indent * 2, 11)
+        indent = Text(" " * self._current_indent)
+        return self._rich_fill_text(rich_text, text_width, indent)
 
-    def start_section(self, heading: str | None) -> None:
-        super().start_section(heading)  # sets self._current_section to child section
-        self._current_section.rich = self._RichSection(self, heading)
+    def _rich_format_action(self, action: argparse.Action) -> Iterator[tuple[Text, Text | None]]:
+        header = self._rich_format_action_invocation(action)
+        header.pad_left(self._current_indent)
+        help = self._rich_expand_help(action) if action.help and action.help.strip() else None
+        yield header, help
+        for subaction in self._iter_indented_subactions(action):
+            yield from self._rich_format_action(subaction)
 
-    def end_section(self) -> None:
-        section_renderable = self._current_section.rich
-        super().end_section()  # sets self._current_section to parent section
-        self._rich_append(section_renderable)
+    def _rich_format_action_invocation(self, action: argparse.Action) -> Text:
+        from rich.text import Text
 
-    def format_help(self) -> str:
-        from rich.console import Console
-        from rich.theme import Theme
+        if not action.option_strings:
+            return Text().append(self._format_action_invocation(action), style="argparse.args")
+        else:
+            action_header = Text(", ").join(Text(o, "argparse.args") for o in action.option_strings)
+            if action.nargs != 0:
+                default = self._get_default_metavar_for_optional(action)
+                args_string = self._format_args(action, default)
+                action_header.append_tokens(((" ", None), (args_string, "argparse.metavar")))
+            return action_header
 
-        super().format_help()
-        console = Console(theme=Theme(self.styles), width=self._width)
-        with console.capture() as capture:
-            for renderable in self._root_section.rich:
-                console.print(renderable)
-        return "\n".join(line.rstrip() for line in capture.get().split("\n"))
+    def _rich_split_lines(self, text: Text, width: int) -> Lines:
+        return self._rich_whitespace_sub(text).wrap(self.console, width)
+
+    def _rich_fill_text(self, text: Text, width: int, indent: Text) -> Text:
+        lines = self._rich_whitespace_sub(text).wrap(self.console, width)
+        return type(text)("\n").join(indent + line for line in lines) + "\n\n"
+
+
+class RawDescriptionRichHelpFormatter(RichHelpFormatter):
+    """Rich help message formatter which retains any formatting in descriptions."""
+
+    def _rich_fill_text(self, text: Text, width: int, indent: Text) -> Text:
+        return type(text)("\n").join(indent + line for line in text.split()) + "\n\n"
+
+
+class RawTextRichHelpFormatter(RawDescriptionRichHelpFormatter):
+    """Rich help message formatter which retains formatting of all help text."""
+
+    def _rich_split_lines(self, text: Text, width: int) -> Lines:
+        return text.split()
+
+
+class ArgumentDefaultsRichHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, RichHelpFormatter):
+    """Rich help message formatter which adds default values to argument help."""
+
+
+class MetavarTypeRichHelpFormatter(argparse.MetavarTypeHelpFormatter, RichHelpFormatter):
+    """Rich help message formatter which uses the argument 'type' as the default
+    metavar value (instead of the argument 'dest').
+    """
 
 
 if __name__ == "__main__":
@@ -249,7 +298,7 @@ if __name__ == "__main__":
             "[link https://docs.python.org/3/library/argparse.html#formatter-class]"
             "argparse's help output[/].\n\n"
             "It makes it easy to use the powers of rich like markup and highlights in your CLI "
-            "help. For example, the line above contains clickable hyperlinks thanks to rich "
+            "help. For example, the first sentence contains clickable hyperlinks thanks to rich's "
             "\\[link] markup. Read below for a peek at available features."
         ),
         epilog=":link: Read more at https://github.com/hamdanal/rich-argparse#usage.",
@@ -258,7 +307,7 @@ if __name__ == "__main__":
         "formatter-class",
         help=(
             "All you need to make you argparse ArgumentParser output colorful text like this is to "
-            "pass it `formatter_class=RichHelpFormatter`."
+            "pass it `formatter_class=RichHelpFormatter` or any of the available variants."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
This is a rewrite of the formatter class in order to add support to raw description/text formatting. New subclasses are added to support all of argparse's help formatters.