### PR TITLE
Use soft_wrap option instead of large fixed width

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: windows-latest
             python-version: "3.9"

--- a/rich_argparse.py
+++ b/rich_argparse.py
@@ -53,7 +53,7 @@ class RichHelpFormatter(argparse.HelpFormatter):
         from rich.theme import Theme
 
         super().__init__(prog, indent_increment, max_help_position, width)
-        self.console = Console(theme=Theme(self.styles), width=5000)
+        self.console = Console(theme=Theme(self.styles))
 
     class _Section(argparse.HelpFormatter._Section):  # type: ignore[valid-type,misc]
         def __init__(
@@ -136,7 +136,7 @@ class RichHelpFormatter(argparse.HelpFormatter):
 
     def format_help(self) -> str:
         with self.console.capture() as capture:
-            self.console.print(self._root_section)
+            self.console.print(self._root_section, highlight=False, soft_wrap=True)
         help = capture.get()
         if help:
             help = self._long_break_matcher.sub("\n\n", help).strip("\n") + "\n"


### PR DESCRIPTION
* `console.print` takes a `soft_wrap` argument.
* also update GitHub CI to use python `3.11` instead of `3.11-dev`