### PR TITLE
Add a style for %(prog)s in the usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+- Add a new style for `%(prog)s` in the usage. The style is applied in argparse-generated usage and
+  in user defined usage whether the user usage is plain text or rich markup.
+  * Issue #55, PR #56
+
 ## 1.0.0 - 2023-01-07
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ class. By default, `RichHelpFormatter` defines the following styles:
     'argparse.metavar': 'dark_cyan',  # for metavariables (e.g. "FILE" in "--file FILE")
     'argparse.syntax': 'bold',  # for highlights of back-tick quoted text (e.g. "`some text`"),
     'argparse.text': 'default',  # for the description, epilog and group descriptions (e.g. "A program to foo")
+    'argparse.prog': 'grey50',  # for %(prog)s in the usage (e.g. "foo" in "Usage: foo [options]")
 }
 ```
 

--- a/stubs/rich_argparse-stubs/__init__.pyi
+++ b/stubs/rich_argparse-stubs/__init__.pyi
@@ -1,4 +1,5 @@
 import argparse
+import re
 from collections.abc import Callable, Iterable, Iterator
 from typing import ClassVar
 
@@ -13,6 +14,7 @@ class RichHelpFormatter(argparse.HelpFormatter):
     highlights: ClassVar[list[str]]
     usage_markup: ClassVar[bool]
     console: Console
+    _printf_style_pattern: re.Pattern[str]
 
     class _Section(argparse.HelpFormatter._Section):  # type: ignore[misc]
         rich_items: list[RenderableType]
@@ -25,6 +27,7 @@ class RichHelpFormatter(argparse.HelpFormatter):
         ) -> None: ...
         def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult: ...
 
+    def _rich_prog_spans(self, usage: str) -> Iterator[Span]: ...
     def _rich_usage_spans(
         self, text: str, start: int, actions: Iterable[argparse.Action]
     ) -> Iterator[Span]: ...

--- a/tests/test_rich_argparse.py
+++ b/tests/test_rich_argparse.py
@@ -269,7 +269,7 @@ def test_generated_usage():
     req_mut_ex.add_argument("-n", help="No.")
 
     usage_text = (
-        "PROG [\x1b[36m-h\x1b[0m] "
+        "\x1b[38;5;244mPROG\x1b[0m [\x1b[36m-h\x1b[0m] "
         "[\x1b[36m--weird\x1b[0m \x1b[38;5;36my)\x1b[0m]  "
         "\x1b[36m--required\x1b[0m \x1b[38;5;36mREQ\x1b[0m "
         "[\x1b[36m--flag\x1b[0m | \x1b[36m--not-flag\x1b[0m] "
@@ -298,9 +298,35 @@ def test_generated_usage():
 @pytest.mark.parametrize(
     ("usage", "expected", "usage_markup"),
     (
-        pytest.param("%(prog)s [bold] CMD[/]", "PROG [bold] CMD[/]", None, id="default"),
-        pytest.param("%(prog)s [bold] CMD[/]", "PROG [bold] CMD[/]", False, id="no_markup"),
-        pytest.param("%(prog)s [bold] CMD[/]", "PROG \x1b[1m CMD\x1b[0m", True, id="markup"),
+        pytest.param(
+            "%(prog)s [bold] PROG_CMD[/]",
+            "\x1b[38;5;244mPROG\x1b[0m [bold] PROG_CMD[/]",
+            None,
+            id="default",
+        ),
+        pytest.param(
+            "%(prog)s [bold] PROG_CMD[/]",
+            "\x1b[38;5;244mPROG\x1b[0m [bold] PROG_CMD[/]",
+            False,
+            id="no_markup",
+        ),
+        pytest.param(
+            "%(prog)s [bold] PROG_CMD[/]",
+            "\x1b[38;5;244mPROG\x1b[0m \x1b[1m PROG_CMD\x1b[0m",
+            True,
+            id="markup",
+        ),
+        pytest.param(
+            "PROG %(prog)s [bold] %(prog)s [/]\n%(prog)r",
+            (
+                "PROG "
+                "\x1b[38;5;244mPROG\x1b[0m "
+                "\x1b[1m \x1b[0m\x1b[1;38;5;244mPROG\x1b[0m\x1b[1m \x1b[0m"
+                "\n\x1b[38;5;244m'PROG'\x1b[0m"
+            ),
+            True,
+            id="prog_prog",
+        ),
     ),
 )
 @pytest.mark.usefixtures("force_color")
@@ -329,8 +355,9 @@ def test_actions_spans_in_usage():
         arg_metavar = "[arg ...]"
 
     usage_text = (
-        f"\x1b[38;5;208mUsage:\x1b[0m PROG [\x1b[36m-h\x1b[0m] [\x1b[36m--opt\x1b[0m \x1b[38;5;36m"
-        f"[OPT]\x1b[0m | \x1b[36m--opts\x1b[0m \x1b[38;5;36mOPTS [OPTS ...]\x1b[0m] "
+        f"\x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG\x1b[0m [\x1b[36m-h\x1b[0m] "
+        f"[\x1b[36m--opt\x1b[0m \x1b[38;5;36m[OPT]\x1b[0m | "
+        f"\x1b[36m--opts\x1b[0m \x1b[38;5;36mOPTS [OPTS ...]\x1b[0m] "
         f"\x1b[36m{arg_metavar}\x1b[0m"
     )
     expected_help_output = f"""\
@@ -353,7 +380,7 @@ def test_boolean_optional_action_spans():  # pragma: >=3.9 cover
     parser = argparse.ArgumentParser("PROG", formatter_class=RichHelpFormatter)
     parser.add_argument("--bool", action=argparse.BooleanOptionalAction)
     expected_help_output = f"""\
-    \x1b[38;5;208mUsage:\x1b[0m PROG [\x1b[36m-h\x1b[0m] [\x1b[36m--bool\x1b[0m | \x1b[36m--no-bool\x1b[0m]
+    \x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG\x1b[0m [\x1b[36m-h\x1b[0m] [\x1b[36m--bool\x1b[0m | \x1b[36m--no-bool\x1b[0m]
 
     \x1b[38;5;208m{OPTIONS_GROUP_NAME}:\x1b[0m
       \x1b[36m-h\x1b[0m, \x1b[36m--help\x1b[0m         \x1b[39mshow this help message and exit\x1b[0m
@@ -374,10 +401,13 @@ def test_usage_spans_errors():
     (usage,) = formatter._root_section.rich_items
     assert isinstance(usage, Text)
     assert str(usage).rstrip() == "Usage: PROG [-h]"
-    (prefix_span,) = usage.spans
+    prefix_span, prog_span = usage.spans
     assert prefix_span.start == 0
     assert prefix_span.end == len("usage:")
     assert prefix_span.style == "argparse.groups"
+    assert prog_span.start == len("usage: ")
+    assert prog_span.end == len("usage: PROG")
+    assert prog_span.style == "argparse.prog"
 
 
 def test_no_help():
@@ -566,7 +596,7 @@ def test_text_highlighter():
     parser.add_argument("arg", help="Did you try `RichHelpFormatter.highlighter`?")
 
     expected_help_output = f"""\
-    \x1b[38;5;208mUsage:\x1b[0m PROG [\x1b[36m-h\x1b[0m] \x1b[36marg\x1b[0m
+    \x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG\x1b[0m [\x1b[36m-h\x1b[0m] \x1b[36marg\x1b[0m
 
     \x1b[38;5;208mPositional Arguments:\x1b[0m
       \x1b[36marg\x1b[0m         \x1b[39mDid you try `\x1b[0m\x1b[1;39mRichHelpFormatter.highlighter\x1b[0m\x1b[39m`?\x1b[0m
@@ -622,3 +652,31 @@ def test_default_highlights():
     \x1b[39mEpilog with `\x1b[0m\x1b[1;39msyntax\x1b[0m\x1b[39m` and \x1b[0m\x1b[36m--options\x1b[0m\x1b[39m.\x1b[0m
     """
     assert parser.format_help().endswith(dedent(expected_help_output))
+
+
+@pytest.mark.usefixtures("force_color")
+def test_subparsers_usage():
+    # Parent uses RichHelpFormatter
+    rich_parent = argparse.ArgumentParser("PROG", formatter_class=RichHelpFormatter)
+    rich_subparsers = rich_parent.add_subparsers()
+    rich_child1 = rich_subparsers.add_parser("sp1", formatter_class=RichHelpFormatter)
+    rich_child2 = rich_subparsers.add_parser("sp2")
+    assert rich_parent.format_usage() == (
+        "\x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG\x1b[0m [\x1b[36m-h\x1b[0m] "
+        "\x1b[36m{sp1,sp2} ...\x1b[0m\n"
+    )
+    assert rich_child1.format_usage() == (
+        "\x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG sp1\x1b[0m [\x1b[36m-h\x1b[0m]\n"
+    )
+    assert rich_child2.format_usage() == "usage: PROG sp2 [-h]\n"
+
+    # Parent uses original formatter
+    orig_parent = argparse.ArgumentParser("PROG")
+    orig_subparsers = orig_parent.add_subparsers()
+    orig_child1 = orig_subparsers.add_parser("sp1", formatter_class=RichHelpFormatter)
+    orig_child2 = orig_subparsers.add_parser("sp2")
+    assert orig_parent.format_usage() == ("usage: PROG [-h] {sp1,sp2} ...\n")
+    assert orig_child1.format_usage() == (
+        "\x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG sp1\x1b[0m [\x1b[36m-h\x1b[0m]\n"
+    )
+    assert orig_child2.format_usage() == "usage: PROG sp2 [-h]\n"


### PR DESCRIPTION
Closes #55

Add a new style for `%(prog)s` in the usage. The style is applied in argparse-generated usage and in user defined usage whether the user usage is plain text or rich markup.

<details>
<summary>Click to see the code</summary>

```python
import argparse

from rich import get_console

from rich_argparse import RichHelpFormatter

console = get_console()


console.rule("Auto generated usage")
parser = argparse.ArgumentParser(
    prog="connect",
    description="Edit or show the location of the user configuration file.",
    formatter_class=RichHelpFormatter,
)
parser.print_usage()


console.rule("User defined plain text usage")
parser = argparse.ArgumentParser(
    prog="connect",
    description="Edit or show the location of the user configuration file.",
    usage="%(prog)s [-h] config_name\n       %(prog)s [-h] url [user] [password]",
    formatter_class=RichHelpFormatter,
)
parser.print_usage()


console.rule("User defined markup usage")
RichHelpFormatter.usage_markup = True
parser = argparse.ArgumentParser(
    prog="connect",
    description="Edit or show the location of the user configuration file.",
    usage="[u]%(prog)s \\[-h] config_name[/]\n       [i]%(prog)s \\[-h] url \\[user] \\[password][/]",
    formatter_class=RichHelpFormatter,
)
parser.print_usage()
```
</details>

![rich_argparse_prog_style](https://user-images.githubusercontent.com/93259987/221349754-1e239ba6-94b6-443d-980e-c0c1a78dad85.png)
