### PR TITLE
Properly handle escaping of control codes in usage and metavars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - `rich_argparse` is now a package instead of a module. This should not affect users.
   * PR #71
 
+### Fixes
+- Fix crash when a metavar following a long option contains control codes.
+  * PR #74
+
 ## 1.1.1 - 2023-05-30
 
 ### Fixes

--- a/rich_argparse/_lazy_rich.py
+++ b/rich_argparse/_lazy_rich.py
@@ -14,6 +14,7 @@ __all__ = [
     "Span",
     "Text",
     "Theme",
+    "CONTROL_STRIP_TRANSLATE",
 ]
 
 if TYPE_CHECKING:
@@ -28,6 +29,8 @@ if TYPE_CHECKING:
     from rich.text import Text as Text
     from rich.theme import Theme as Theme
 
+    CONTROL_STRIP_TRANSLATE: dict[int, None]
+
 
 def __getattr__(name: str) -> Any:
     if name not in __all__:
@@ -38,6 +41,7 @@ def __getattr__(name: str) -> Any:
     import rich.style
     import rich.text
     import rich.theme
+    from rich.control import STRIP_CONTROL_CODES
 
     globals().update(
         {
@@ -51,6 +55,7 @@ def __getattr__(name: str) -> Any:
             "Span": rich.text.Span,
             "Text": rich.text.Text,
             "Theme": rich.theme.Theme,
+            "CONTROL_STRIP_TRANSLATE": dict.fromkeys(STRIP_CONTROL_CODES),
         }
     )
     return globals()[name]

--- a/rich_argparse/_lazy_rich.py
+++ b/rich_argparse/_lazy_rich.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 def __getattr__(name: str) -> Any:
     if name not in __all__:
-        raise AttributeError(name)  # pragma: no cover
+        raise AttributeError(name)
     import rich.console
     import rich.containers
     import rich.markup
@@ -39,16 +39,18 @@ def __getattr__(name: str) -> Any:
     import rich.text
     import rich.theme
 
-    exported = {
-        "Console": rich.console.Console,
-        "ConsoleOptions": rich.console.ConsoleOptions,
-        "RenderableType": rich.console.RenderableType,
-        "RenderResult": rich.console.RenderResult,
-        "Lines": rich.containers.Lines,
-        "escape": rich.markup.escape,
-        "StyleType": rich.style.StyleType,
-        "Span": rich.text.Span,
-        "Text": rich.text.Text,
-        "Theme": rich.theme.Theme,
-    }
-    return exported[name]
+    globals().update(
+        {
+            "Console": rich.console.Console,
+            "ConsoleOptions": rich.console.ConsoleOptions,
+            "RenderableType": rich.console.RenderableType,
+            "RenderResult": rich.console.RenderResult,
+            "Lines": rich.containers.Lines,
+            "escape": rich.markup.escape,
+            "StyleType": rich.style.StyleType,
+            "Span": rich.text.Span,
+            "Text": rich.text.Text,
+            "Theme": rich.theme.Theme,
+        }
+    )
+    return globals()[name]

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -37,12 +37,14 @@ from tests.conftest import Parsers, get_cmd_output
 
 # helpers
 # =======
-def clean(text: str) -> str:
+def clean(text: str, dedent: bool = True) -> str:
     if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
         # replace "optional arguments:" with "options:"
         pos = text.lower().index("optional arguments:")
         text = text[: pos + 6] + text[pos + 17 :]
-    return textwrap.dedent(text)
+    if dedent:
+        text = textwrap.dedent(text)
+    return text
 
 
 class ArgumentParsers(Parsers[ArgumentParser, _ArgumentGroup, Type[HelpFormatter]]):
@@ -758,3 +760,30 @@ def test_rich_lazy_import():
 
     with pytest.raises(AttributeError, match="Foo"):
         _ = r.Foo
+
+
+def test_help_with_control_codes():
+    parsers = ArgumentParsers(HelpFormatter, RichHelpFormatter, prog="PROG\r\nRAM")
+    parsers.add_argument(
+        "--long-option-with-control-codes-in-metavar", metavar="META\r\nVAR", help="%(metavar)s"
+    )
+    orig_parser, rich_parser = parsers.parsers
+    orig_help = orig_parser.format_help().lower()
+    rich_help = rich_parser.format_help().lower()
+    assert rich_help == orig_help.replace("\r", "")  # rich strips \r and other control codes
+
+    expected_help_text = """\
+\x1b[38;5;208mUsage:\x1b[0m \x1b[38;5;244mPROG\x1b[0m
+\x1b[38;5;244mRAM\x1b[0m [\x1b[36m-h\x1b[0m] [\x1b[36m--long-option-with-control-codes-in-metavar\x1b[0m \x1b[38;5;36mMETA\x1b[0m
+\x1b[38;5;36mVAR\x1b[0m]
+
+\x1b[38;5;208mOptional Arguments:\x1b[0m
+  \x1b[36m-h\x1b[0m, \x1b[36m--help\x1b[0m            \x1b[39mshow this help message and exit\x1b[0m
+  \x1b[36m--long-option-with-control-codes-in-metavar\x1b[0m \x1b[38;5;36mMETA\x1b[0m
+\x1b[38;5;36mVAR\x1b[0m
+                        \x1b[39mMETA VAR\x1b[0m
+"""
+    with patch("rich.console.Console.is_terminal", return_value=True):
+        colored_help_text = rich_parser.format_help()
+    # cannot use textwrap.dedent because of the control codes
+    assert colored_help_text == clean(expected_help_text, dedent=False)


### PR DESCRIPTION
This fixes a crash when a metavar following a long option contains control codes.

Also improve performance of the lazy rich module.