### PR TITLE
Make `RichHelpFormatter` itself renderable with rich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+- Make `RichHelpFormatter` itself a rich renderable.
+  * PR #90
+
 ## 1.3.0 - 2023-08-19
 
 ### Features

--- a/rich_argparse/_lazy_rich.py
+++ b/rich_argparse/_lazy_rich.py
@@ -12,6 +12,8 @@ __all__ = [
     "Lines",
     "strip_control_codes",
     "escape",
+    "Padding",
+    "Segment",
     "StyleType",
     "Span",
     "Text",
@@ -27,6 +29,8 @@ if TYPE_CHECKING:
     from rich.containers import Lines as Lines
     from rich.control import strip_control_codes as strip_control_codes
     from rich.markup import escape as escape
+    from rich.padding import Padding as Padding
+    from rich.segment import Segment as Segment
     from rich.style import StyleType as StyleType
     from rich.text import Span as Span
     from rich.text import Text as Text
@@ -41,6 +45,8 @@ def __getattr__(name: str) -> Any:
     import rich.containers
     import rich.control
     import rich.markup
+    import rich.padding
+    import rich.segment
     import rich.style
     import rich.text
     import rich.theme
@@ -55,6 +61,8 @@ def __getattr__(name: str) -> Any:
             "Lines": rich.containers.Lines,
             "strip_control_codes": rich.control.strip_control_codes,
             "escape": rich.markup.escape,
+            "Padding": rich.padding.Padding,
+            "Segment": rich.segment.Segment,
             "StyleType": rich.style.StyleType,
             "Span": rich.text.Span,
             "Text": rich.text.Text,


### PR DESCRIPTION
This is a new approach that allows the formatter itself to be rendered with rich. The handling of whitespace manipulation and wrapping is now baked into the renderable itself. This also removes the need to use `soft_wrap=True` when printing the formatted help. The downside is that the code is now very low-level in terms of rich rendering, it needs to do line-by-line handling of `Segment` objects.

This could help unblock more niche use-cases like #81 and #54.