### PR TITLE
Allow arbitrary renderables in the descriptions and epilog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Add a style for default values when using `%(default)s` in the help text.
   * Issue [#84](https://github.com/hamdanal/rich-argparse/issues/84),
     PR [#98](https://github.com/hamdanal/rich-argparse/pull/98)
+- Allow arbitrary renderables in the descriptions and epilog
+  * PR [#99](https://github.com/hamdanal/rich-argparse/pull/99)
 
 ## 1.3.0 - 2023-08-19
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ changes to the code.
   * [Highlighting patterns](#special-text-highlighting)
   * ["usage"](#colors-in-the-usage)
   * [--version](#colors-in---version)
+  * [Rich renderables](#rich-descriptions-and-epilog)
 * [Subparsers](#working-with-subparsers)
 * [Documenting your CLI](#generate-help-preview)
 * [Third party formatters](#working-with-third-party-formatters) (ft. django)
@@ -145,6 +146,44 @@ parser.add_argument(
 
 Note that the `argparse.text` style is applied to the `version` string similar to the description
 and epilog.
+
+### Rich descriptions and epilog
+
+You can use any rich renderable in the descriptions and epilog. This includes all built-in rich
+renderables like `Table` and `Markdown` and any custom renderables defined using the
+[Console Protcol](https://rich.readthedocs.io/en/stable/protocol.html#console-protocol).
+
+```python
+import argparse
+from rich.markdown import Markdown
+from rich_argparse import RichHelpFormatter
+
+description = """
+# My program
+
+This is a markdown description of my program.
+
+* It has a list
+* And a table
+
+| Column 1 | Column 2 |
+| -------- | -------- |
+| Value 1  | Value 2  |
+"""
+parser = argparse.ArgumentParser(
+    description=Markdown(description, style="argparse.text"),
+    formatter_class=RichHelpFormatter,
+)
+...
+```
+Certain features are **disabled** for arbitrary renderables other than strings, including:
+
+* Syntax highlighting with `RichHelpFormatter.highlights`
+* Styling with the `"argparse.text"` style defined in `RichHelpFormatter.styles`
+* Replacement of `%(prog)s` with the program name
+
+Arbitrary renderables are displayed "as is" except for long runs of empty lines that get truncated
+to two empty lines following the behavior of argparse.
 
 ## Working with subparsers
 

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -896,11 +896,9 @@ def test_rich_renderables():
 
     \x1b[33m──────────────────────────────────────────────────────────────────────────────────────────────────\x1b[0m
 
-
      \x1b[1m \x1b[0m\x1b[1mfoo\x1b[0m\x1b[1m \x1b[0m \x1b[1m \x1b[0m\x1b[1mbar\x1b[0m
      ━━━━━━━━━━━
       1     2
-
 
     \x1b[38;5;208mOptional Arguments:\x1b[0m
       \x1b[36m-h\x1b[0m, \x1b[36m--help\x1b[0m  \x1b[39mshow this help message and exit\x1b[0m


### PR DESCRIPTION
PR #90 changed the internals of `RichHelpFormatter` to use low level rendering. This lifted some of the restrictions on what can be rendered without sacrificing parity with the argparse formatters.

This PR officially adds support for arbitrary renderables as descriptions (both parser and groups description) and epilog.