### PR TITLE
Fix `%(default)s` style when help markup is deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+- [GH-121](https://github.com/hamdanal/rich-argparse/issues/115),
+  [PR-123](https://github.com/hamdanal/rich-argparse/pull/116)
+  Fix `%(default)s` style when help markup is deactivated.
+
 ## 1.5.0 - 2024-06-01
 
 ### Features

--- a/rich_argparse/__init__.py
+++ b/rich_argparse/__init__.py
@@ -370,13 +370,14 @@ class RichHelpFormatter(argparse.HelpFormatter):
         # raise ValueError if needed
         help_string % params  # pyright: ignore[reportUnusedExpression]
         parts = []
+        default_span: r.Span | None = None
         last = 0
         for m in self._printf_style_pattern.finditer(help_string):
             start, end = m.span()
             parts.append(help_string[last:start])
             sub = r.escape(help_string[start:end] % params)
             if m.group("mapping") == "default":
-                sub = f"[argparse.default]{sub}[/argparse.default]"
+                default_span = r.Span(start, start + len(sub), "argparse.default")
             parts.append(sub)
             last = end
         parts.append(help_string[last:])
@@ -385,6 +386,8 @@ class RichHelpFormatter(argparse.HelpFormatter):
             if self.help_markup
             else r.Text("".join(parts), style="argparse.help")
         )
+        if default_span:
+            rich_help.spans.append(default_span)
         for highlight in self.highlights:
             rich_help.highlight_regex(highlight, style_prefix="argparse.")
         return rich_help

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1006,7 +1006,7 @@ def test_disable_help_markup():
     parser = ArgumentParser(
         prog="PROG", formatter_class=RichHelpFormatter, description="[red]Description text.[/]"
     )
-    parser.add_argument("--foo", help="[red]Help text.[/]")
+    parser.add_argument("--foo", default="def", help="[red]Help text (default: %(default)s).[/]")
     with patch.object(RichHelpFormatter, "help_markup", False):
         help_text = parser.format_help()
     expected_help_text = """\
@@ -1016,7 +1016,7 @@ def test_disable_help_markup():
 
     Optional Arguments:
       -h, --help  show this help message and exit
-      --foo FOO   [red]Help text.[/]
+      --foo FOO   [red]Help text (default: def).[/]
     """
     assert help_text == clean(expected_help_text)
 


### PR DESCRIPTION
Fixes https://github.com/hamdanal/rich-argparse/issues/121#issuecomment-2151415554