### PR TITLE
sdist: include the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 *.pyc
+*.swp
 /.coverage
 /.tox
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Issue-Tracker = "https://github.com/hamdanal/rich-argparse/issues"
 Changelog = "https://github.com/hamdanal/rich-argparse/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["/.github", "/.vscode", "/scripts", "/.pre-commit-config.yaml", "dist*"]
+include = ["CHANGELOG.md", "CONTRIBUTING.md", "requirements-dev.txt", "rich_argparse", "tests", "LICENSE", "README.md", "pyproject.toml" ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["rich_argparse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,11 @@ Documentation = "https://github.com/hamdanal/rich-argparse#rich-argparse"
 Issue-Tracker = "https://github.com/hamdanal/rich-argparse/issues"
 Changelog = "https://github.com/hamdanal/rich-argparse/blob/main/CHANGELOG.md"
 
-[tool.hatch]
-build.packages = ["rich_argparse"]
+[tool.hatch.build.targets.sdist]
+exclude = ["/.github", "/.vscode", "/scripts", "/.pre-commit-config.yaml", "dist*"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["rich_argparse"]
 
 [tool.tox]
 requires = ["tox>=4.21.0"]


### PR DESCRIPTION
Hello, I'm packaging `rich-argparse` for Debian. It would be nice if the next release included the tests so we can run them both at package build time, and later against the installed package.

Thanks!

Before:
```
$ python3 -m build 
* Creating venv isolated environment...
* Installing packages in isolated environment... (hatchling>=1.11.0)
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating venv isolated environment...
* Installing packages in isolated environment... (hatchling>=1.11.0)
* Getting build dependencies for wheel...
* Building wheel...
Successfully built rich_argparse-1.6.0.tar.gz and rich_argparse-1.6.0-py3-none-any.whl

$ tar tf dist/rich_argparse-1.6.0.tar.gz 
rich_argparse-1.6.0/rich_argparse/__init__.py
rich_argparse-1.6.0/rich_argparse/__main__.py
rich_argparse-1.6.0/rich_argparse/_common.py
rich_argparse-1.6.0/rich_argparse/_lazy_rich.py
rich_argparse-1.6.0/rich_argparse/optparse.py
rich_argparse-1.6.0/rich_argparse/py.typed
rich_argparse-1.6.0/.gitignore
rich_argparse-1.6.0/LICENSE
rich_argparse-1.6.0/README.md
rich_argparse-1.6.0/pyproject.toml
rich_argparse-1.6.0/PKG-INFO

$ unzip -l dist/rich_argparse-1.6.0-py3-none-any.whl 
Archive:  dist/rich_argparse-1.6.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
    25106  2020-02-02 00:00   rich_argparse/__init__.py
     3286  2020-02-02 00:00   rich_argparse/__main__.py
     2542  2020-02-02 00:00   rich_argparse/_common.py
     2151  2020-02-02 00:00   rich_argparse/_lazy_rich.py
    13197  2020-02-02 00:00   rich_argparse/optparse.py
        0  2020-02-02 00:00   rich_argparse/py.typed
    14301  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/METADATA
       87  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/WHEEL
     1067  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/licenses/LICENSE
      817  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/RECORD
---------                     -------
    62554                     10 files

```

After:
```
$ python3 -m build 
* Creating venv isolated environment...
* Installing packages in isolated environment... (hatchling>=1.11.0)
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating venv isolated environment...
* Installing packages in isolated environment... (hatchling>=1.11.0)
* Getting build dependencies for wheel...
* Building wheel...
Successfully built rich_argparse-1.6.0.tar.gz and rich_argparse-1.6.0-py3-none-any.whl

$ tar tf dist/rich_argparse-1.6.0.tar.gz 
rich_argparse-1.6.0/CHANGELOG.md
rich_argparse-1.6.0/CONTRIBUTING.md
rich_argparse-1.6.0/requirements-dev.txt
rich_argparse-1.6.0/rich_argparse/__init__.py
rich_argparse-1.6.0/rich_argparse/__main__.py
rich_argparse-1.6.0/rich_argparse/_common.py
rich_argparse-1.6.0/rich_argparse/_lazy_rich.py
rich_argparse-1.6.0/rich_argparse/optparse.py
rich_argparse-1.6.0/rich_argparse/py.typed
rich_argparse-1.6.0/tests/__init__.py
rich_argparse-1.6.0/tests/conftest.py
rich_argparse-1.6.0/tests/requirements.txt
rich_argparse-1.6.0/tests/test_argparse.py
rich_argparse-1.6.0/tests/test_optparse.py
rich_argparse-1.6.0/.gitignore
rich_argparse-1.6.0/LICENSE
rich_argparse-1.6.0/README.md
rich_argparse-1.6.0/pyproject.toml
rich_argparse-1.6.0/PKG-INFO

$ unzip -l dist/rich_argparse-1.6.0-py3-none-any.whl 
Archive:  dist/rich_argparse-1.6.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
    25106  2020-02-02 00:00   rich_argparse/__init__.py
     3286  2020-02-02 00:00   rich_argparse/__main__.py
     2542  2020-02-02 00:00   rich_argparse/_common.py
     2151  2020-02-02 00:00   rich_argparse/_lazy_rich.py
    13197  2020-02-02 00:00   rich_argparse/optparse.py
        0  2020-02-02 00:00   rich_argparse/py.typed
    14301  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/METADATA
       87  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/WHEEL
     1067  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/licenses/LICENSE
      817  2020-02-02 00:00   rich_argparse-1.6.0.dist-info/RECORD
---------                     -------
    62554                     10 files
