### PR TITLE
Add proper django support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,6 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
-        additional_dependencies: ["rich"]
+        additional_dependencies: ["rich", "types-colorama", "django-stubs"]
+        pass_filenames: false
+        args: ["rich_argparse"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Unreleased
 
 ### Features
+- [PR-148](https://github.com/hamdanal/rich-argparse/pull/148)
+  Add support for django commands in the new `rich_argparse.django` module. Read more at
+  https://github.com/hamdanal/rich-argparse#django-support
 - [GH-140](https://github.com/hamdanal/rich-argparse/issues/140),
   [PR-147](https://github.com/hamdanal/rich-argparse/pull/147)
-  Add `rich_argparse.contrib` module to provide additional non-standard formatters. The new module
-  currently contains a single formatter `ParagraphRichHelpFormatter` that preserves paragraph breaks
-  (`\n\n`) in the descriptions, epilog, and help text.
+  Add `ParagraphRichHelpFormatter`, a formatter that preserves paragraph breaks, in the new
+  `rich_argparse.contrib` module. Read more at
+  https://github.com/hamdanal/rich-argparse#additional-formatters
 
 ### Fixes
 - [GH-141](https://github.com/hamdanal/rich-argparse/issues/141),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Features
-- [PR-148](https://github.com/hamdanal/rich-argparse/pull/148)
+- [PR-149](https://github.com/hamdanal/rich-argparse/pull/149)
   Add support for django commands in the new `rich_argparse.django` module. Read more at
   https://github.com/hamdanal/rich-argparse#django-support
 - [GH-140](https://github.com/hamdanal/rich-argparse/issues/140),

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ _More formatters will be added in the future._
 project by adding these two lines to the `manage.py` file:
 
 ```diff
+diff --git a/manage.py b/manage.py
  def main():
      """Run administrative tasks."""
      os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'my_project.settings')
@@ -273,28 +274,23 @@ project by adding these two lines to the `manage.py` file:
              "available on your PYTHONPATH environment variable? Did you "
              "forget to activate a virtual environment?"
          ) from exc
-+    from rich_argparse.django import patch_django_base_command
-+    patch_django_base_command()
++    from rich_argparse.django import richify_command_line_help
++    richify_command_line_help()
      execute_from_command_line(sys.argv)
 ```
 
-Alternatively, you can use *rich-argparse* with specific commands using the `patch_django_command`
-decorator or using the `DjangoRichHelpFormatter` class directly:
+Alternatively, you can use the `DjangoRichHelpFormatter` class directly in your commands:
 
-```python
-# In my_app/management/commands/my_command.py
+```diff
+diff --git a/my_app/management/commands/my_command.py b/my_app/management/commands/my_command.py
 from django.core.management.base import BaseCommand
-from rich_argparse.django import DjangoRichHelpFormatter, patch_django_command
++from rich_argparse.django import DjangoRichHelpFormatter
 
-# Option 1
-@patch_django_command
-class Command(BaseCommand): ...
-
-# Option 2
 class Command(BaseCommand):
-    def create_parser(self, *args, **kwargs):
-        kwargs.setdefault("formatter_class", DjangoRichHelpFormatter)
-        return super().create_parser(*args, **kwargs)
+    def add_arguments(self, parser):
++        parser.formatter_class = DjangoRichHelpFormatter
+        parser.add_argument("--option", action="store_true", help="An option")
+        ...
 ```
 
 ## Optparse support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,12 @@ flake8-tidy-imports.ban-relative-imports = "all"
 python_version = "3.8"
 strict = true
 
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+check_untyped_defs = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,6 @@ flake8-tidy-imports.ban-relative-imports = "all"
 python_version = "3.8"
 strict = true
 
-[[tool.mypy.overrides]]
-module = ["tests.*"]
-check_untyped_defs = false
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/rich_argparse/_patching.py
+++ b/rich_argparse/_patching.py
@@ -49,7 +49,7 @@ def patch_default_formatter_class(
     def decorator(cls, /):
         method = getattr(cls, method_name)
         if not callable(method):
-            raise TypeError(f"{cls.__name__}.{method_name} is not callable")
+            raise TypeError(f"'{cls.__name__}.{method_name}' is not callable")
 
         @functools.wraps(method)
         def wrapper(*args, **kwargs):

--- a/rich_argparse/_patching.py
+++ b/rich_argparse/_patching.py
@@ -1,0 +1,64 @@
+# Source code: https://github.com/hamdanal/rich-argparse
+# MIT license: Copyright (c) Ali Hamdan <ali.hamdan.dev@gmail.com>
+
+# for internal use only
+from __future__ import annotations
+
+from rich_argparse._argparse import RichHelpFormatter
+
+
+def patch_default_formatter_class(
+    cls=None, /, *, formatter_class=RichHelpFormatter, method_name="__init__"
+):
+    """Patch the default `formatter_class` parameter of an argument parser constructor.
+
+    Parameters
+    ----------
+    cls : (type, optional)
+        The class to patch. If not provided, a decorator is returned.
+    formatter_class : (type, optional)
+        The new formatter class to use. Defaults to ``RichHelpFormatter``.
+    method_name : (str, optional)
+        The method name to patch. Defaults to ``__init__``.
+
+    Examples
+    --------
+    Can be used as a normal function to patch an existing class::
+
+        # Patch the default formatter class of `argparse.ArgumentParser`
+        patch_default_formatter_class(argparse.ArgumentParser)
+
+        # Patch the default formatter class of django commands
+        from django.core.management.base import BaseCommand, DjangoHelpFormatter
+        class DjangoRichHelpFormatter(DjangoHelpFormatter, RichHelpFormatter): ...
+        patch_default_formatter_class(
+            BaseCommand, formatter_class=DjangoRichHelpFormatter, method_name="create_parser"
+        )
+    Or as a decorator to patch a new class::
+
+        @patch_default_formatter_class
+        class MyArgumentParser(argparse.ArgumentParser):
+            pass
+
+        @patch_default_formatter_class(formatter_class=RawDescriptionRichHelpFormatter)
+        class MyOtherArgumentParser(argparse.ArgumentParser):
+            pass
+    """
+    import functools
+
+    def decorator(cls, /):
+        method = getattr(cls, method_name)
+        if not callable(method):
+            raise TypeError(f"{cls.__name__}.{method_name} is not callable")
+
+        @functools.wraps(method)
+        def wrapper(*args, **kwargs):
+            kwargs.setdefault("formatter_class", formatter_class)
+            return method(*args, **kwargs)
+
+        setattr(cls, method_name, wrapper)
+        return cls
+
+    if cls is None:
+        return decorator
+    return decorator(cls)

--- a/rich_argparse/_patching.pyi
+++ b/rich_argparse/_patching.pyi
@@ -1,0 +1,28 @@
+# Source code: https://github.com/hamdanal/rich-argparse
+# MIT license: Copyright (c) Ali Hamdan <ali.hamdan.dev@gmail.com>
+
+# for internal use only
+from argparse import _FormatterClass
+from collections.abc import Callable
+from typing import TypeVar, overload
+
+from rich_argparse._argparse import RichHelpFormatter
+
+_T = TypeVar("_T", bound=type)
+
+@overload
+def patch_default_formatter_class(
+    cls: None = None,
+    /,
+    *,
+    formatter_class: _FormatterClass = RichHelpFormatter,
+    method_name: str = "__init__",
+) -> Callable[[_T], _T]: ...
+@overload
+def patch_default_formatter_class(
+    cls: _T,
+    /,
+    *,
+    formatter_class: _FormatterClass = RichHelpFormatter,
+    method_name: str = "__init__",
+) -> _T: ...

--- a/rich_argparse/django.py
+++ b/rich_argparse/django.py
@@ -1,6 +1,6 @@
 # Source code: https://github.com/hamdanal/rich-argparse
 # MIT license: Copyright (c) Ali Hamdan <ali.hamdan.dev@gmail.com>
-"""Django-specific utilities for rich help messages."""
+"""Django-specific utilities for rich command line help."""
 
 from __future__ import annotations
 
@@ -9,15 +9,12 @@ try:
 except ImportError as e:  # pragma: no cover
     raise ImportError("rich_argparse.django requires django to be installed.") from e
 
-from functools import partial as _partial
-
 from rich_argparse._argparse import RichHelpFormatter as _RichHelpFormatter
 from rich_argparse._patching import patch_default_formatter_class as _patch_default_formatter_class
 
 __all__ = [
     "DjangoRichHelpFormatter",
-    "patch_django_command",
-    "patch_django_base_command",
+    "richify_command_line_help",
 ]
 
 
@@ -25,41 +22,18 @@ class DjangoRichHelpFormatter(_DjangoHelpFormatter, _RichHelpFormatter):
     """A rich help formatter for django commands."""
 
 
-def patch_django_base_command(
+def richify_command_line_help(
     formatter_class: type[_RichHelpFormatter] = DjangoRichHelpFormatter,
 ) -> None:
-    """Patch django's ``BaseCommand`` to use a rich help formatter project-wide.
+    """Set a rich default formatter class for ``BaseCommand`` project-wide.
 
-    Calling this function affects all built-in, third-party, and user defined commands.
+    Calling this function affects all built-in, third-party, and user defined django commands.
+
+    Note that this function only changes the **default** formatter class of commands. User commands
+    can still override the default by explicitly setting a formatter class.
     """
     from django.core.management.base import BaseCommand
 
     _patch_default_formatter_class(
         BaseCommand, formatter_class=formatter_class, method_name="create_parser"
     )
-
-
-patch_django_command = _partial(
-    _patch_default_formatter_class,
-    formatter_class=DjangoRichHelpFormatter,
-    method_name="create_parser",
-)
-"""Patch a ``BaseCommand`` subclass to use a rich help formatter.
-
-Usage::
-
-    from django.core.management.base import BaseCommand
-    from rich_argparse.django import patch_django_command
-
-    @patch_django_command
-    class Command(BaseCommand): ...
-
-You can also use a custom help formatter::
-
-    from rich_argparse.django import DjangoRichHelpFormatter
-
-    class MyAwesomeHelpFormatter(DjangoRichHelpFormatter): ...
-
-    @patch_django_command(formatter_class=MyAwesomeHelpFormatter)
-    class Command(BaseCommand): ...
-"""

--- a/rich_argparse/django.py
+++ b/rich_argparse/django.py
@@ -1,0 +1,65 @@
+# Source code: https://github.com/hamdanal/rich-argparse
+# MIT license: Copyright (c) Ali Hamdan <ali.hamdan.dev@gmail.com>
+"""Django-specific utilities for rich help messages."""
+
+from __future__ import annotations
+
+try:
+    from django.core.management.base import DjangoHelpFormatter as _DjangoHelpFormatter
+except ImportError as e:  # pragma: no cover
+    raise ImportError("rich_argparse.django requires django to be installed.") from e
+
+from functools import partial as _partial
+
+from rich_argparse._argparse import RichHelpFormatter as _RichHelpFormatter
+from rich_argparse._patching import patch_default_formatter_class as _patch_default_formatter_class
+
+__all__ = [
+    "DjangoRichHelpFormatter",
+    "patch_django_command",
+    "patch_django_base_command",
+]
+
+
+class DjangoRichHelpFormatter(_DjangoHelpFormatter, _RichHelpFormatter):
+    """A rich help formatter for django commands."""
+
+
+def patch_django_base_command(
+    formatter_class: type[_RichHelpFormatter] = DjangoRichHelpFormatter,
+) -> None:
+    """Patch django's ``BaseCommand`` to use a rich help formatter project-wide.
+
+    Calling this function affects all built-in, third-party, and user defined commands.
+    """
+    from django.core.management.base import BaseCommand
+
+    _patch_default_formatter_class(
+        BaseCommand, formatter_class=formatter_class, method_name="create_parser"
+    )
+
+
+patch_django_command = _partial(
+    _patch_default_formatter_class,
+    formatter_class=DjangoRichHelpFormatter,
+    method_name="create_parser",
+)
+"""Patch a ``BaseCommand`` subclass to use a rich help formatter.
+
+Usage::
+
+    from django.core.management.base import BaseCommand
+    from rich_argparse.django import patch_django_command
+
+    @patch_django_command
+    class Command(BaseCommand): ...
+
+You can also use a custom help formatter::
+
+    from rich_argparse.django import DjangoRichHelpFormatter
+
+    class MyAwesomeHelpFormatter(DjangoRichHelpFormatter): ...
+
+    @patch_django_command(formatter_class=MyAwesomeHelpFormatter)
+    class Command(BaseCommand): ...
+"""

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1092,17 +1092,24 @@ def test_patching():
     class MyArgumentParser(ArgumentParser):
         not_callable = None
 
+    # Patch existing class
     patch_default_formatter_class(MyArgumentParser)
     assert MyArgumentParser().formatter_class is RichHelpFormatter
 
-    @patch_default_formatter_class(formatter_class=RichHelpFormatter)
+    # Override previous patch
+    patch_default_formatter_class(MyArgumentParser, formatter_class=MetavarTypeRichHelpFormatter)
+    assert MyArgumentParser().formatter_class is MetavarTypeRichHelpFormatter
+
+    # Patch new class
+    @patch_default_formatter_class(formatter_class=ArgumentDefaultsRichHelpFormatter)
     class MyArgumentParser2(ArgumentParser):
         pass
 
-    assert MyArgumentParser2().formatter_class is RichHelpFormatter
+    assert MyArgumentParser2().formatter_class is ArgumentDefaultsRichHelpFormatter
 
-    with pytest.raises(AttributeError):
-        patch_default_formatter_class(MyArgumentParser, method_name="unknown_method")
+    # Errors
+    with pytest.raises(AttributeError, match=r"'MyArgumentParser' has no attribute 'missing'"):
+        patch_default_formatter_class(MyArgumentParser, method_name="missing")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"'MyArgumentParser\.not_callable' is not callable"):
         patch_default_formatter_class(MyArgumentParser, method_name="not_callable")

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -34,6 +34,7 @@ from rich_argparse import (
     RichHelpFormatter,
 )
 from rich_argparse._common import _fix_legacy_win_text
+from rich_argparse._patching import patch_default_formatter_class
 from tests.helpers import ArgumentParsers, clean_argparse, get_cmd_output
 
 
@@ -1085,3 +1086,23 @@ def test_metavar_spans():
       \x1b[36m--op7\x1b[0m \x1b[38;5;36mMET1\x1b[0m \x1b[38;5;36mMET2\x1b[0m \x1b[38;5;36mMET3\x1b[0m
     """
     assert help_text == clean_argparse(expected_help_text)
+
+
+def test_patching():
+    class MyArgumentParser(ArgumentParser):
+        not_callable = None
+
+    patch_default_formatter_class(MyArgumentParser)
+    assert MyArgumentParser().formatter_class is RichHelpFormatter
+
+    @patch_default_formatter_class(formatter_class=RichHelpFormatter)
+    class MyArgumentParser2(ArgumentParser):
+        pass
+
+    assert MyArgumentParser2().formatter_class is RichHelpFormatter
+
+    with pytest.raises(AttributeError):
+        patch_default_formatter_class(MyArgumentParser, method_name="unknown_method")
+
+    with pytest.raises(TypeError):
+        patch_default_formatter_class(MyArgumentParser, method_name="not_callable")

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -23,29 +23,14 @@ def patch_django_import():
         yield
 
 
-def test_patch_django_base_command():
+def test_richify_command_line_help():
     from django.core.management.base import BaseCommand, DjangoHelpFormatter
 
-    from rich_argparse.django import DjangoRichHelpFormatter, patch_django_base_command
+    from rich_argparse.django import DjangoRichHelpFormatter, richify_command_line_help
 
     parser = BaseCommand().create_parser("", "")
     assert parser.formatter_class is DjangoHelpFormatter
 
-    patch_django_base_command()
+    richify_command_line_help()
     parser = BaseCommand().create_parser("", "")
-    assert parser.formatter_class is DjangoRichHelpFormatter
-
-
-def test_patch_django_command():
-    from django.core.management.base import BaseCommand, DjangoHelpFormatter
-
-    from rich_argparse.django import DjangoRichHelpFormatter, patch_django_command
-
-    @patch_django_command
-    class Command(BaseCommand): ...
-
-    parser = BaseCommand().create_parser("", "")
-    assert parser.formatter_class is DjangoHelpFormatter
-
-    parser = Command().create_parser("", "")
     assert parser.formatter_class is DjangoRichHelpFormatter

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser, HelpFormatter
+from unittest.mock import patch
+
+
+class DjangoHelpFormatter(HelpFormatter): ...
+
+
+def create_base_command():
+    class BaseCommand:
+        def create_parser(self, *args, **kwargs):
+            kwargs.setdefault("formatter_class", DjangoHelpFormatter)
+            return ArgumentParser(*args, **kwargs)
+
+    return BaseCommand
+
+
+@patch("django.core.management.base.DjangoHelpFormatter", new=DjangoHelpFormatter)
+@patch("django.core.management.base.BaseCommand", new=create_base_command())
+def test_patch_django_base_command():
+    from django.core.management.base import BaseCommand
+
+    from rich_argparse.django import DjangoRichHelpFormatter, patch_django_base_command
+
+    parser = BaseCommand().create_parser("", "")
+    assert parser.formatter_class is DjangoHelpFormatter
+
+    patch_django_base_command()
+    parser = BaseCommand().create_parser("", "")
+    assert parser.formatter_class is DjangoRichHelpFormatter
+
+
+@patch("django.core.management.base.DjangoHelpFormatter", new=DjangoHelpFormatter)
+@patch("django.core.management.base.BaseCommand", new=create_base_command())
+def test_patch_django_command():
+    from django.core.management.base import BaseCommand
+
+    from rich_argparse.django import DjangoRichHelpFormatter, patch_django_command
+
+    @patch_django_command
+    class Command(BaseCommand): ...
+
+    parser = BaseCommand().create_parser("", "")
+    assert parser.formatter_class is DjangoHelpFormatter
+
+    parser = Command().create_parser("", "")
+    assert parser.formatter_class is DjangoRichHelpFormatter


### PR DESCRIPTION
Add module `rich_argparse.django` with a `DjangoRichHelpFormatter` class and a `richify_command_line_help` function that makes all commands of a project use rich-argparse.