### PR TITLE
Fix `ValueError` when using `%(default)s` inside square brackets and `help_markup` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   https://github.com/hamdanal/rich-argparse#additional-formatters
 
 ### Fixes
+- [GH-152](https://github.com/hamdanal/rich-argparse/issues/152),
+  [PR-153](https://github.com/hamdanal/rich-argparse/pull/153)
+  Fix `ValueError` when using `%(default)s` inside square brackets and `help_markup` is enabled.
 - [GH-141](https://github.com/hamdanal/rich-argparse/issues/141),
   [PR-142](https://github.com/hamdanal/rich-argparse/pull/142)
   Do not highlight --options inside backticks.


### PR DESCRIPTION
Fixes #152 